### PR TITLE
Creating the 'dev' branch and onboarding fixes

### DIFF
--- a/dialog/en-us/pairing.paired.dialog
+++ b/dialog/en-us/pairing.paired.dialog
@@ -1,1 +1,1 @@
-Now I am ready for use.  Try asking me things like "what's the weather", "tell me about abraham lincoln", or "play the news".  If you need to stop me talking at any time, just push my button.
+Now I am ready for use.  Try asking me things like "hey mycroft, what's the weather", "hey mycroft, tell me about abraham lincoln", or "hey mycroft, play the news".  If you need to stop me talking at any time, just push my button.


### PR DESCRIPTION
- The pairing code now stops speaking once pairing has triggered (e.g. if speaking starts just before code is accepted)
