### PR TITLE
Fix a few final details when PairingSkill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,7 @@ class PairingSkill(MycroftSkill):
         else:
             self.last_request = time.time() + self.expiration
             self.data = self.api.get_code(self.state)
-            self.enclosure.deactivate_mouth_events()
+            self.enclosure.deactivate_mouth_events()  # keeps code on the display
             self.enclosure.mouth_text(self.data.get("code"))
             self.speak_code()
             self.__create_activator()
@@ -101,15 +101,23 @@ class PairingSkill(MycroftSkill):
             except:
                 pass
 
+            self.enclosure.activate_mouth_events()  # clears the display
+            self.speak_dialog("pairing.paired")
+            
+            # wait_while_speaking() support is mycroft-core 0.8.16+
+            try:
+                mycroft.util.wait_while_speaking()
+            except:
+                pass
+
+            IdentityManager.save(login)
+            self.emitter.emit(Message("mycroft.paired", login))
+
             # Un-mute.  Would have been muted during onboarding for a new
             # unit, and not dangerous to do if pairing was started
             # independently.
             self.emitter.emit(Message("mycroft.mic.unmute", None))
 
-            self.enclosure.activate_mouth_events()
-            self.speak_dialog("pairing.paired")
-            IdentityManager.save(login)
-            self.emitter.emit(Message("mycroft.paired", login))
         except:
             if self.last_request < time.time():
                 self.data = None


### PR DESCRIPTION
* The "unmute" shouldn't happen until the final speech completes.  It includes examples that contain "hey mycroft" and we don't want it self-triggering
* Similarly, we don't want the pairing saved until speech is complete to prevent accidental button press