### PR TITLE
Add check for failure to get pairing code

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,6 +79,7 @@ class PairingSkill(MycroftSkill):
             try:
                 self.data = self.api.get_code(self.state)
             except ConnectionError:
+                self.speak_dialog('connection.error')
                 self.emitter.emit(Message("mycroft.mic.unmute", None))
                 return
 

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@
 import time
 from threading import Timer
 from uuid import uuid4
+from requests import ConnectionError
 
 from adapt.intent import IntentBuilder
 from mycroft.api import DeviceApi
@@ -75,8 +76,14 @@ class PairingSkill(MycroftSkill):
             self.speak_code()
         else:
             self.last_request = time.time() + self.expiration
-            self.data = self.api.get_code(self.state)
-            self.enclosure.deactivate_mouth_events() # keeps code on the display
+            try:
+                self.data = self.api.get_code(self.state)
+            except ConnectionError:
+                self.emitter.emit(Message("mycroft.mic.unmute", None))
+                return
+
+            # Make sure code stays on display
+            self.enclosure.deactivate_mouth_events()
             self.speak_code()
             if not self.activator:
                 self.__create_activator()

--- a/dialog/en-us/connection.error.dialog
+++ b/dialog/en-us/connection.error.dialog
@@ -1,0 +1,1 @@
+Connection to mycroft.ai failed, pairing code could not be fetched. Check your internet connection and try again.


### PR DESCRIPTION
If a unboxing sequence is started while Internet connection is missing it would error out and leave Mycroft in a muted state.