### PR TITLE
Update configuration when pairing is complete

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,6 +129,8 @@ class PairingSkill(MycroftSkill):
             # independently.
             self.emitter.emit(Message("mycroft.mic.unmute", None))
 
+            # Send signal to update configuration
+            self.emitter.emit(Message("configuration.updated"))
         except:
             # speak pairing code every 60th second
             with self.counter_lock:


### PR DESCRIPTION
Send the `configuration.updated` message to update the configuration as soon as the pairing has completed. otherwise up to a minute can pass before the config is fetched and timezone and location are updated accordingly.