### PR TITLE
Fix potential reload issue and refine UX

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -94,14 +94,13 @@ class PairingSkill(MycroftSkill):
 
                 self.speak_dialog("pairing.intro")
 
-                # HACK this gives the Mark 1 time to scroll the address, the
-                # mouth_text() really should take an optional parameter to
-                # not scroll.
+                # HACK this gives the Mark 1 time to scroll the address and
+                # the user time to browse to the website.
+                # TODO: mouth_text() really should take an optional parameter
+                # to not scroll a second time.
                 self.enclosure.mouth_text("home.mycroft.ai      ")
                 time.sleep(7)
                 mycroft.util.wait_while_speaking()
-
-                # Give user time to open browser and get to the website before talking more
             except:
                 pass
 
@@ -196,6 +195,7 @@ class PairingSkill(MycroftSkill):
                 self.activator.cancel()
         if self.activator:
             self.activator.join()
+
 
 def create_skill():
     return PairingSkill()

--- a/__init__.py
+++ b/__init__.py
@@ -87,6 +87,9 @@ class PairingSkill(MycroftSkill):
                 self.emitter.emit(Message("mycroft.mic.unmute", None))
                 return
 
+            # Make sure code stays on display
+            self.enclosure.deactivate_mouth_events()
+
             # wait_while_speaking() support is mycroft-core 0.8.16+
             try:
                 # This will make sure the user is in 0.8.16+ before continuing
@@ -103,9 +106,6 @@ class PairingSkill(MycroftSkill):
                 mycroft.util.wait_while_speaking()
             except:
                 pass
-
-            # Make sure code stays on display
-            self.enclosure.deactivate_mouth_events()
 
             if not self.activator:
                 self.__create_activator()
@@ -184,6 +184,9 @@ class PairingSkill(MycroftSkill):
         code = self.data.get("code")
         self.log.info("Pairing code: " + code)
         data = {"code": '. '.join(map(self.nato_dict.get, code))}
+        
+        # Make sure code stays on display
+        self.enclosure.deactivate_mouth_events()
         self.enclosure.mouth_text(self.data.get("code"))
         self.speak_dialog("pairing.code", data)
 

--- a/dialog/en-us/pairing.code.dialog
+++ b/dialog/en-us/pairing.code.dialog
@@ -1,1 +1,3 @@
-I'm connected to the internet and need to be activated.  Register me at home dot mycroft dot A.I with the code. {{code}}
+You can register me by going to Devices, selecting Add Device then use the code {{code}} 
+Register this device with the code {{code}}
+Enter the code {{code}}

--- a/dialog/en-us/pairing.intro.dialog
+++ b/dialog/en-us/pairing.intro.dialog
@@ -1,0 +1,1 @@
+I'm connected to the internet and need to be activated.  Open your browser and visit home dot mycroft dot A I to register this device.


### PR DESCRIPTION
There was a chance that the pairing would shutdown/restart from a disk
change in the middle of pairing.  Now code updates are blocked while
pairing.

Also added display of the web address for home to the faceplate before
displaying the registration code.