### PR TITLE
Better startup and error handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,21 +26,25 @@ import mycroft.util
 
 
 class PairingSkill(MycroftSkill):
+
+    poll_frequency = 10  # secs between checking server for activation
+    
     def __init__(self):
         super(PairingSkill, self).__init__("PairingSkill")
         self.api = DeviceApi()
         self.data = None
-        self.last_request = None
+        self.time_code_expires = None
         self.state = str(uuid4())
-        self.delay = 10  # poll time used in checking server for activation
-        self.expiration = 72000  # 20 hours
         self.activator = None
         self.activator_lock = Lock()
         self.activator_cancelled = False
-        self.counter_lock = Lock()
-        self.count = 0  # Counter for when to repeat the code
 
-        # TODO: Add translation support
+        self.counter_lock = Lock()
+        self.count = -1  # for repeating pairing code. -1 = not running
+
+        # TODO:18.02 Add translation support
+        # Can't change before then for fear of breaking really old mycroft-core
+        # instances that just came up on wifi and haven't upgraded code yet.
         self.nato_dict = {'A': "'A' as in Apple", 'B': "'B' as in Bravo",
                           'C': "'C' as in Charlie", 'D': "'D' as in Delta",
                           'E': "'E' as in Echo", 'F': "'F' as in Fox trot",
@@ -60,6 +64,7 @@ class PairingSkill(MycroftSkill):
                           '0': 'Zero'}
 
     def initialize(self):
+        # TODO:18.02 - use decorator
         intent = IntentBuilder("PairingIntent") \
             .require("PairingKeyword").require("DeviceKeyword").build()
         self.register_intent(intent, self.handle_pairing)
@@ -70,38 +75,48 @@ class PairingSkill(MycroftSkill):
         self.handle_pairing()
 
     def handle_pairing(self, message=None):
-        with self.counter_lock:
-            self.counter = 0
-
         if self.is_paired():
+            # Already paired!  Just tell user
             self.speak_dialog("pairing.paired")
+        elif self.count > -1:
+            # We snuck in to this handler somehow while the pairing process
+            # is still being setup.  Ignore it.
+            self.log.debug("Ignoring call to handle_pairing")
         elif not self.data:
-            # Prevent auto-update during the pairing process
-            self.reload_skill = False
+            # Not paired or already pairing, so start the process.
+            with self.counter_lock:
+                self.count = 0
+            self.reload_skill = False  # Prevent restart during the process
 
-            self.last_request = time.time() + self.expiration
+            self.log.debug("Kicking off pairing sequence")
+
             try:
+                # Obtain a pairing code from the backend
                 self.data = self.api.get_code(self.state)
+                
+                # Keep track of when the code was obtained.  The codes expire
+                # after 20 hours.
+                self.time_code_expires = time.time() + 72000  # 20 hours
             except ConnectionError:
+                self.log.debug("Failed to get pairing code")
                 self.speak_dialog('connection.error')
                 self.emitter.emit(Message("mycroft.mic.unmute", None))
                 return
 
-            # Make sure code stays on display
-            self.enclosure.deactivate_mouth_events()
-
             # wait_while_speaking() support is mycroft-core 0.8.16+
             try:
                 # This will make sure the user is in 0.8.16+ before continuing
+                # so a < 0.8.16 system will skip writing the URL to the mouth
                 mycroft.util.wait_while_speaking()
 
                 self.speak_dialog("pairing.intro")
 
+                self.enclosure.deactivate_mouth_events()
+                self.enclosure.mouth_text("home.mycroft.ai      ")
                 # HACK this gives the Mark 1 time to scroll the address and
                 # the user time to browse to the website.
                 # TODO: mouth_text() really should take an optional parameter
                 # to not scroll a second time.
-                self.enclosure.mouth_text("home.mycroft.ai      ")
                 time.sleep(7)
                 mycroft.util.wait_while_speaking()
             except:
@@ -110,35 +125,53 @@ class PairingSkill(MycroftSkill):
             if not self.activator:
                 self.__create_activator()
 
-    def on_activate(self):
+    def check_for_activate(self):
         """
-            Function used by Timer. Checks if user has activated the device
-            on home.mycroft.ai and if not repeats the pairing code every
-            60 second.
+            Function called ever 10 seconds by Timer. Checks if user has
+            activated the device yet on home.mycroft.ai and if not repeats
+            the pairing code every 60 seconds.
         """
         try:
-            # wait for a signal from the backend that pairing is complete
+            # Attempt to activate.  If the user has completed pairing on the,
+            # backend, this will succeed.  Otherwise it throws and HTTPError()
             token = self.data.get("token")
-            login = self.api.activate(self.state, token)
+            login = self.api.activate(self.state, token)  # HTTPError() thrown
+
+            # When we get here, the pairing code has been entered on the
+            # backend and pairing can now be saved.
+            # The following is kinda ugly, but it is really critical that we get
+            # this saved successfully or we need to let the user know that they
+            # have to perform pairing all over again at the website.
+            try:
+                IdentityManager.save(login)
+            except Exception as e:
+                self.log.debug("First save attempt failed: " + repr(e))
+                time.sleep(2)
+                try:
+                    IdentityManager.save(login)
+                except Exception as e2:
+                    # Something must be seriously wrong
+                    self.log.debug("Second save attempt failed: " + repr(e2))
+                    self.abort_and_restart()
 
             # is_speaking() and stop_speaking() support is mycroft-core 0.8.16+
             try:
                 if mycroft.util.is_speaking():
-                    # Assume speaking is the pairing code.  Stop TTS
+                    # Assume speaking is the pairing code.  Stop TTS of that.
                     mycroft.util.stop_speaking()
             except:
                 pass
 
             self.enclosure.activate_mouth_events()  # clears the display
+            
+            # Tell user they are now paired
             self.speak_dialog("pairing.paired")
-
-            # wait_while_speaking() support is mycroft-core 0.8.16+
             try:
                 mycroft.util.wait_while_speaking()
             except:
                 pass
 
-            IdentityManager.save(login)
+            # Notify the system it is paired and ready
             self.emitter.emit(Message("mycroft.paired", login))
 
             # Un-mute.  Would have been muted during onboarding for a new
@@ -151,23 +184,43 @@ class PairingSkill(MycroftSkill):
 
             # Allow this skill to auto-update again
             self.reload_skill = True
-        except:
+        except HTTPError:
             # speak pairing code every 60th second
             with self.counter_lock:
                 if self.count == 0:
                     self.speak_code()
                 self.count = (self.count + 1) % 6
 
-            if self.last_request < time.time():
+            if time.time() > self.time_code_expires:
+                # After 20 hours the token times out.  Restart
+                # the pairing process.
+                with self.counter_lock:
+                    self.count = -1
                 self.data = None
                 self.handle_pairing()
             else:
+                # trigger another check in 10 seconds
                 self.__create_activator()
+        except Exception as e:
+            self.log.debug("Unexpected error: " + repr(e))
+            self.abort_and_restart()
+            
+    def abort_and_restart(self):
+        # restart pairing sequence
+        self.enclosure.activate_mouth_events()
+        self.speak_dialog("unexpected.error.restarting")
+        self.emitter.emit(Message("mycroft.not.paired", login))
+        self.count = -1
+        self.activator = None
+
 
     def __create_activator(self):
+        # Create a timer that will poll the backend in 10 seconds to see
+        # if the user has completed the device registration process
         with self.activator_lock:
             if not self.activator_cancelled:
-                self.activator = Timer(self.delay, self.on_activate)
+                self.activator = Timer(PairingSkill.poll_frequency,
+                                       self.check_for_activate)
                 self.activator.daemon = True
                 self.activator.start()
 

--- a/__init__.py
+++ b/__init__.py
@@ -102,7 +102,8 @@ class PairingSkill(MycroftSkill):
                 self.log.debug("Failed to get pairing code: " + repr(e))
                 self.speak_dialog('connection.error')
                 self.emitter.emit(Message("mycroft.mic.unmute", None))
-                self.count = -1
+                with self.counter_lock:
+                    self.count = -1
                 return
 
             # wait_while_speaking() support is mycroft-core 0.8.16+
@@ -214,7 +215,8 @@ class PairingSkill(MycroftSkill):
         self.enclosure.activate_mouth_events()
         self.speak_dialog("unexpected.error.restarting")
         self.emitter.emit(Message("mycroft.not.paired", login))
-        self.count = -1
+        with self.counter_lock:
+            self.count = -1
         self.activator = None
 
     def __create_activator(self):

--- a/__init__.py
+++ b/__init__.py
@@ -15,8 +15,7 @@
 import time
 from threading import Timer, Lock
 from uuid import uuid4
-from requests import ConnectionError
-
+from requests import HTTPError
 from adapt.intent import IntentBuilder
 from mycroft.api import DeviceApi
 from mycroft.identity import IdentityManager
@@ -99,14 +98,16 @@ class PairingSkill(MycroftSkill):
                 # Keep track of when the code was obtained.  The codes expire
                 # after 20 hours.
                 self.time_code_expires = time.time() + 72000  # 20 hours
-            except ConnectionError:
-                self.log.debug("Failed to get pairing code")
+            except Exception as e:
+                self.log.debug("Failed to get pairing code: " + repr(e))
                 self.speak_dialog('connection.error')
                 self.emitter.emit(Message("mycroft.mic.unmute", None))
                 self.count = -1
                 return
 
             # wait_while_speaking() support is mycroft-core 0.8.16+
+            # TODO:18.02 - Remove this try/catch and migrate to the preferred
+            # mycroft.audio.wait_while_speaking
             try:
                 # This will make sure the user is in 0.8.16+ before continuing
                 # so a < 0.8.16 system will skip writing the URL to the mouth

--- a/dialog/en-us/unexpected.error.restarting.dialog
+++ b/dialog/en-us/unexpected.error.restarting.dialog
@@ -1,0 +1,1 @@
+My apologies, something unexpected has happened.  I need to restart the pairing process.


### PR DESCRIPTION
The pairing process had several holes in it.  It could:
* Start multiple times if the server was slow to respond to
  a call to self.api.get_code(self.state)
* Restart after the pairing completed on the server if
  there was an exception from writing to the disk
* Other potential timing issues

These changes are intended to prevent all of this from from occurring