### PR TITLE
Notify system paired earlier

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -167,6 +167,9 @@ class PairingSkill(MycroftSkill):
 
             self.enclosure.activate_mouth_events()  # clears the display
 
+            # Notify the system it is paired
+            self.bus.emit(Message("mycroft.paired", login))
+
             with self.pair_dialog_lock:
                 if self.mycroft_ready:
                     # Tell user they are now paired
@@ -175,9 +178,6 @@ class PairingSkill(MycroftSkill):
                 else:
                     self.speak_dialog("wait.for.startup")
                     mycroft.audio.wait_while_speaking()
-
-            # Notify the system it is paired and ready
-            self.bus.emit(Message("mycroft.paired", login))
 
             # Un-mute.  Would have been muted during onboarding for a new
             # unit, and not dangerous to do if pairing was started


### PR DESCRIPTION
This PR makes it so that https://github.com/MycroftAI/skill-mark-2-pi/pull/10 can show the paired complete and intro screens in sync with dialog and not after the long dialog. 

We unmute the mic, poll settings and push the settings manifest on this paired event. All things which are welcome to be done a bit earlier, but let me know if I missed something. 