### PR TITLE
Fix scalable UI page missing preventing Pairing

### DIFF
--- a/ui/create_account_scalable.qml
+++ b/ui/create_account_scalable.qml
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 by Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.4
+
+import Mycroft 1.0 as Mycroft
+
+/* Define a screen requesting that a user create an account before pairing. */
+Mycroft.Delegate {
+    id: root
+    leftPadding: 0
+    rightPadding: 0
+    bottomPadding: 0
+    topPadding: 0
+    property int gridUnit: Mycroft.Units.gridUnit
+
+    Rectangle {
+        id: background
+        anchors.fill: parent
+        color: "#22a7f0"
+
+        PairingLabel {
+            id: firstLine
+            anchors.bottom: secondLine.top
+            anchors.bottomMargin: gridUnit * 3
+            fontSize: 82
+            fontStyle: "Bold"
+            heightUnits: 4
+            text: "Create a Mycroft"
+        }
+
+        PairingLabel {
+            id: secondLine
+            anchors.bottom: thirdLine.top
+            anchors.bottomMargin: gridUnit * 2
+            fontSize: 82
+            fontStyle: "Bold"
+            heightUnits: 4
+            text: "account at"
+        }
+
+        PairingLabel {
+            id: thirdLine
+            anchors.verticalCenter: parent.verticalCenter
+            textColor: "#2C3E50"
+            fontSize: 59
+            fontStyle: "Bold"
+            heightUnits: 3
+            text: "account.mycroft.ai"
+        }
+
+        PairingLabel {
+            id: fourthLine
+            anchors.top: thirdLine.bottom
+            anchors.topMargin: gridUnit * 2
+            textColor: "#2C3E50"
+            fontSize: 35
+            fontStyle: "Regular"
+            heightUnits: 2
+            text: "pairing will begin shortly"
+        }
+
+        Rectangle {
+            id: progressBarBackground
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: gridUnit * 2
+            anchors.horizontalCenter: parent.horizontalCenter
+            color: "#91D3F8"
+            height: gridUnit * 2
+            radius: 16
+            width: gridUnit * 46
+        }
+
+        Rectangle {
+            id: progressBarForeground
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: gridUnit * 2
+            anchors.left: progressBarBackground.left
+            color: "#FD9E66"
+            height: gridUnit * 2
+            radius: 16
+
+            NumberAnimation on width {
+                id: progressBarAnimation
+                to: gridUnit * 46
+                duration: 30000
+            }
+        }
+    }
+}

--- a/ui/pairing_code_scalable.qml
+++ b/ui/pairing_code_scalable.qml
@@ -29,7 +29,6 @@ Mycroft.Delegate {
     rightPadding: 0
     bottomPadding: 0
     topPadding: 0
-    property var pairingCode: sessionData.code
 
     Rectangle {
         color: "#22a7f0"
@@ -52,7 +51,7 @@ Mycroft.Delegate {
                 minimumPixelSize: 65
                 font.pixelSize: Math.max(root.height * 0.25, minimumPixelSize)
                 color: "white"
-                text: root.pairingCode
+                text: sessionData.pairingCode
             }
 
             Item {
@@ -65,15 +64,15 @@ Mycroft.Delegate {
             Item {
                 id: pairAtItem
                 anchors.top: screenCenter.bottom
-                anchors.left: parent.left
                 anchors.topMargin: 24
-                width: parent.width / 4
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
                 height: pairAtText.paintedHeight
 
                 Text {
                     id: pairAtText
                     width: parent.width
-                    horizontalAlignment: Text.AlignRight
+                    horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     wrapMode: Text.WordWrap
                     elide: Text.ElideRight
@@ -85,24 +84,22 @@ Mycroft.Delegate {
             }
             Item {
                 id: urlItem
-                anchors.top: screenCenter.bottom
+                anchors.top: pairAtItem.bottom
                 anchors.topMargin: 24
-                anchors.left: pairAtItem.right
-                anchors.leftMargin: Kirigami.Units.smallSpacing * 3
                 width: parent.width
                 height: pairAtText.paintedHeight
 
                 Text {
                     id: urlText
                     width: parent.width
-                    horizontalAlignment: Text.AlignLeft
+                    horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     wrapMode: Text.WordWrap
                     elide: Text.ElideRight
                     font.weight: Font.Bold
                     font.pixelSize: root.height * 0.08
                     color: "#2C3E50"
-                    text: "account.mycroft.ai/pair"
+                    text: "mycroft.ai/pair"
                 }
             }
         }

--- a/ui/pairing_start_scalable.qml
+++ b/ui/pairing_start_scalable.qml
@@ -42,7 +42,7 @@ Mycroft.Delegate {
 
             Image {
                 id: img
-                source: Qt.resolvedUrl("images/phone.png")
+                source: Qt.resolvedUrl("images/phone.svg")
                 Layout.preferredWidth: horizontalMode ? parent.width / 2 : parent.width
                 Layout.preferredHeight: horizontalMode ? parent.height * 0.9 : parent.height / 2
                 Layout.alignment: Qt.AlignBottom
@@ -55,7 +55,7 @@ Mycroft.Delegate {
                 Layout.fillHeight: true
 
                 Kirigami.Heading {
-                    id: sentence
+                    id: firstLine
                     Layout.fillWidth: true
                     Layout.alignment: horizontalMode ? Qt.AlignLeft : Qt.AlignHCenter | Qt.AlignVCenter
                     Layout.leftMargin: horizontalMode ? spacingUnit : 0
@@ -65,7 +65,20 @@ Mycroft.Delegate {
                     elide: Text.ElideRight
                     font.weight: Font.Bold
                     font.pixelSize: horizontalMode ? root.width * 0.050 : root.height * 0.065
-                    text: "I need to be activated, pair at"
+                    text: "I need to be activated,"
+                }
+                Kirigami.Heading {
+                    id: secondLine
+                    Layout.fillWidth: true
+                    Layout.alignment: horizontalMode ? Qt.AlignLeft : Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.leftMargin: horizontalMode ? spacingUnit : 0
+                    horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
+                    verticalAlignment: horizontalMode ? Text.AlignVCenter : Text.AlignTop
+                    wrapMode: Text.WordWrap
+                    elide: Text.ElideRight
+                    font.weight: Font.Bold
+                    font.pixelSize: horizontalMode ? root.width * 0.050 : root.height * 0.065
+                    text: "pair me at"
                 }
                 Kirigami.Heading {
                     id: url
@@ -79,7 +92,7 @@ Mycroft.Delegate {
                     font.weight: Font.Bold
                     font.pixelSize: horizontalMode ? root.width * 0.035 : root.height * 0.05
                     color: "#22a7f0"
-                    text: "account.mycroft.ai/pair"
+                    text: "mycroft.ai/pair"
                 }
             }
         }

--- a/ui/pairing_success_scalable.qml
+++ b/ui/pairing_success_scalable.qml
@@ -33,10 +33,10 @@ Mycroft.ProportionalDelegate {
             id: statusIcon
             visible: true
             enabled: true
-            anchors.horizontalCenter: grid.horizontalCenter
+            Layout.alignment: Qt.AlignHCenter
             Layout.preferredWidth: proportionalGridUnit * 50
             Layout.preferredHeight: proportionalGridUnit * 50
-            source: Qt.resolvedUrl("check_circle.svg")
+            source: Qt.resolvedUrl("images/check_circle.svg")
         }
 
         /* Add some spacing between icon and text */


### PR DESCRIPTION
#### Description
The latest version of the Skill was failing to load on non-Mark II systems that have a GUI due to a missing page - `create_account_scalable.qml`

While addressing this I improved a few other layout issues. I'm sure it's not perfect, but definitely better. Pull requests for further layout improvements are most welcome!

#### Type of PR
- [x] Bugfix

#### Testing
Pair device on a desktop with the GUI running.

#### CLA
- [x] Yes