### PR TITLE
Fix pairing code not displaying on Mark 1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -236,7 +236,9 @@ class PairingSkill(MycroftSkill):
         self.log.debug("Speaking pairing code")
         pairing_code_utterance = map(self.nato_alphabet.get, self.pairing_code)
         speak_data = dict(code='. '.join(pairing_code_utterance) + '.')
-        self.speak_dialog("pairing.code", speak_data)
+        # TODO - There is a bug in the Mark 1 where the pairing code display is
+        # immediately cleared if we do not wait for this dialog to be spoken.
+        self.speak_dialog("pairing.code", speak_data, wait=True)
 
     def _start_device_activation_checker(self):
         """Set a timer to check the activation status in ten seconds."""


### PR DESCRIPTION
#### Description
The pairing code was not displaying on the Mark 1 following the latest update. I don't yet know why - but if you set the wait flag
on this dialog to True then it works as expected.

Setting a long sleep immediately before the dialog is spoken does not have the same result so it is something to do with `speak_dialog()` and potentially `_attempt_activation()` that is called immediately after it.

Edit: this seems to be more sporadic. This change will at least keep the pairing code displayed for the duration of the dialog.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Pair a Mark II using the latest version of the Pairing Skill.

#### CLA
- [x] Yes